### PR TITLE
Remove precompiled headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
       <artifactId>maven-core</artifactId>
       <version>2.2.1</version>
     </dependency>
-    
+
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-container-default</artifactId>
@@ -144,24 +144,24 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId> 
+      <artifactId>plexus-utils</artifactId>
       <version>2.0.5</version>
-    </dependency> 
-    <dependency> 
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>1.0</version> 
+      <version>1.0</version>
       <exclusions>
-        <exclusion>  
-          <groupId>org.codehaus.plexus</groupId> 
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-component-api</artifactId>
         </exclusion>
-      </exclusions> 
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.onespatial</groupId>
       <artifactId>cpptasks-parallel</artifactId>
-      <version>1.0-beta-5-parallel-3-SNAPSHOT</version>
+      <version>1.0-beta-5-parallel-2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.bcel</groupId>
@@ -196,14 +196,14 @@
           <version>2.3.2</version>
         </plugin>
       </plugins>
-    </pluginManagement>  
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <source>1.4</source>
-          <target>1.4</target>      
+          <target>1.4</target>
         </configuration>
       </plugin>
       <plugin>
@@ -238,7 +238,7 @@
         <version>2.2</version>
       </plugin>
     </plugins>
-  </reporting>  
+  </reporting>
 
   <profiles>
     <profile>

--- a/src/main/java/org/apache/maven/plugin/nar/AbstractCompileMojo.java
+++ b/src/main/java/org/apache/maven/plugin/nar/AbstractCompileMojo.java
@@ -477,14 +477,10 @@ public abstract class AbstractCompileMojo
                 {
                     String pchName = pchFiles[index].getName().replace(".pch", ".h");
                     String absolutePchName = pchDir + File.separator +  pchName;
-                    addCompileOption(cppCompiler, "/Yu" + absolutePchName);
-                    addCompileOption(cppCompiler, "/FI" + absolutePchName); //force inclusion of pch file
                     if(debug)
                     {
                         pchName = pchName.replace(".h", ".pdb");
                         File pdbFile = new File(pchDir, pchName);
-                        if(pdbFile.exists())
-                            addCompileOption(cppCompiler, "/Fd" + pdbFile.getPath());
                     }
                 }
             }

--- a/src/main/java/org/apache/maven/plugin/nar/AbstractCompileMojo.java
+++ b/src/main/java/org/apache/maven/plugin/nar/AbstractCompileMojo.java
@@ -346,18 +346,7 @@ public abstract class AbstractCompileMojo
 
             narInfo.setLibrary(getAOL(), output);
 
-            Set pchNames = new HashSet();
-            //Add all the source files from pch libraries to a list
-            for(Iterator libraryIterator = libraries.iterator(); libraryIterator.hasNext();)
-                if(((Library)libraryIterator.next()).getType().equals(Library.PCH))
-                {
-                    //Only supported for C++
-                    List sources = getSourcesFor(getCpp());
-                    for(Iterator sourcesIterator = sources.iterator(); sourcesIterator.hasNext();)
-                        pchNames.add(((File)sourcesIterator.next()).getName());
-                }
-            //add this info to the narInfo
-            narInfo.setPchNames(getAOL(), pchNames);
+            // Add this info to the narInfo
             narInfo.setTargetWinRT(getAOL(), isTargetWinRT());
             narInfo.setCreateNuget(getAOL(), createNugetPackage);
         }
@@ -450,57 +439,10 @@ public abstract class AbstractCompileMojo
         return getSourcesFromSourceDirectories(compiler, srcDirs);
     }
 
-    protected void addPrecompiledHeaderOptions(Compiler cppCompiler, String scope)
-    throws MojoExecutionException, MojoFailureException
-    {
-        for ( Iterator i = getNarManager().getNarDependencies( scope ).iterator(); i.hasNext(); )
-        {
-            NarArtifact narDependency = (NarArtifact) i.next();
-            String binding = narDependency.getNarInfo().getBinding(getAOL(), Library.STATIC);
-            getLog().debug( "Looking for " + narDependency + " found binding " + binding);
-            if (binding.equals(Library.PCH ) )
-            {
-                getLog().debug("Found pch dependency " + narDependency.getArtifactId());
-                File unpackDirectory = getUnpackDirectory();
-                File pchDir =
-                    getLayout().getLibDirectory(unpackDirectory, narDependency.getArtifactId(),
-                            narDependency.getVersion(), getAOL().toString(), binding);
-
-                File[] pchFiles = pchDir.listFiles(new FilenameFilter()
-                {
-                    public boolean accept(File dir, String name)
-                    {
-                        return name.endsWith(".pch");
-                    }
-                });
-                for(int index = 0; index < pchFiles.length; index++)
-                {
-                    String pchName = pchFiles[index].getName().replace(".pch", ".h");
-                    String absolutePchName = pchDir + File.separator +  pchName;
-                    if(debug)
-                    {
-                        pchName = pchName.replace(".h", ".pdb");
-                        File pdbFile = new File(pchDir, pchName);
-                    }
-                }
-            }
-        }
-    }
-
     protected void addCompileOption(Compiler compiler, String option)
     {
         getLog().debug("Added compile option " + option);
         compiler.addOption(option);
-    }
-
-    protected void addPchObjFiles(LinkerDef linkerDefinition, String binding,
-            File libraryDirectory)
-    {
-        if(binding.equals(Library.PCH))
-        {
-            getLog().debug("adding precomiled header obj file");
-            addObjFiles(linkerDefinition, libraryDirectory);
-        }
     }
 
     protected void addObjFiles(LinkerDef linkerDefinition, File libraryDirectory)

--- a/src/main/java/org/apache/maven/plugin/nar/Library.java
+++ b/src/main/java/org/apache/maven/plugin/nar/Library.java
@@ -43,8 +43,6 @@ public class Library
 
     public static final String NONE = "none"; // no library produced
 
-    public static final String PCH = "pch";
-
     /**
      * Type of the library to generate. Possible choices are: "plugin", "shared", "static", "jni" or "executable".
      * Defaults to "shared".

--- a/src/main/java/org/apache/maven/plugin/nar/NarInfo.java
+++ b/src/main/java/org/apache/maven/plugin/nar/NarInfo.java
@@ -47,8 +47,6 @@ public class NarInfo
 
     public static final String NAR_PROPERTIES = "nar.properties";
 
-    private static final String PCH_NAMES = "pch.names";
-
     private String groupId, artifactId, version;
 
     private Properties info;
@@ -273,26 +271,5 @@ public class NarInfo
     public final boolean isCreateNuget(AOL aol)
     {
         return getProperty(aol, CREATE_NUGET, false);
-    }
-
-    public final void setPchNames(AOL aol, Set pchNames)
-    {
-        if(pchNames.isEmpty())
-            return;
-        StringBuilder builder = new StringBuilder();
-        for(Iterator it = pchNames.iterator(); it.hasNext();)
-        {
-            if(builder.length() != 0)
-                builder.append(", ");
-            String pchName = (String)it.next();
-            int extensionIndex = pchName.lastIndexOf(".");
-            builder.append(pchName.substring(0, extensionIndex));
-        }
-        setProperty(aol, PCH_NAMES, builder.toString());
-    }
-
-    public final String getPchNames(AOL aol)
-    {
-        return getProperty(aol, PCH_NAMES, "");
     }
 }

--- a/src/main/java/org/apache/maven/plugin/nar/NarTestCompileMojo.java
+++ b/src/main/java/org/apache/maven/plugin/nar/NarTestCompileMojo.java
@@ -116,9 +116,6 @@ public class NarTestCompileMojo
         runtimeType.setValue( getRuntime( getAOL() ) );
         task.setRuntime( runtimeType );
 
-        // add precompiled header options
-        addPrecompiledHeaderOptions(getCpp(), "test");
-
         // add C++ compiler
         CompilerDef cpp = getCpp().getCompiler( type, test.getName() );
         if ( cpp != null )
@@ -325,9 +322,6 @@ public class NarTestCompileMojo
                     sysLibSet.setLibs( new CUtil.StringArrayBuilder( sysLibs ) );
                     task.addSyslibset( sysLibSet );
                 }
-
-                //Add obj files for pre compiled headers to the linker
-                addPchObjFiles(linkerDefinition, binding, dir);
             }
         }
 

--- a/src/main/java/org/apache/maven/plugin/nar/NarVisualStudioSetupTags.java
+++ b/src/main/java/org/apache/maven/plugin/nar/NarVisualStudioSetupTags.java
@@ -26,15 +26,6 @@ public interface NarVisualStudioSetupTags
     public static final String HEADER_FILE_ELEMENTS = "[#headerFileElements#]";
     public static final String SOURCE_FILE_ELEMENTS = "[#sourceFileElements#]";
     public static final String NEW_GUID = "[#newGUID#]";
-    public static final String USE_PRE_COMPILED_HEADERS = "[#usePreCompiledHeader#]";
-    public static final String CLEAN_PRE_COMPILED_HEADERS = "[#cleanPreCompiledHeaders#]";
-    public static final String COPY_PRE_COMPILED_HEADER_FILE = "[#copyPrecompiledHeaderFile#]";
-    public static final String PRE_COMPILED_HEADER_H = "[#preCompiledHeader.h#]";
-    public static final String PRE_COMPILED_HEADER_PDB = "[#preCompiledHeader.pdb#]";
-    public static final String FORCED_INCLUDES = "[#forcedIncludes#]";
-    public static final String PRE_COMPILED_HEADER_H_DEBUG = "[#preCompiledHeader.hDebug#]";
-    public static final String PRE_COMPILED_HEADER_PDB_DEBUG = "[#preCompiledHeader.pdbDebug#]";
-    public static final String FORCED_INCLUDES_DEBUG = "[#forcedIncludesDebug#]";
     public static final String RUNTIME_LIBRARY = "[#runtimeLibrary#]";
     public static final String RUNTIME_LIBRARY_DEBUG = "[#runtimeLibraryDebug#]";
 }

--- a/src/main/java/org/apache/maven/plugin/nar/ProjectInfo.java
+++ b/src/main/java/org/apache/maven/plugin/nar/ProjectInfo.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.Set;
 
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.nar.NarVisualStudioSetupMojo.PchInfo;
 
 public class ProjectInfo
 {
@@ -17,14 +16,22 @@ public class ProjectInfo
     private Set headerFiles;
     private Set sourceFiles;
     private File directory;
-    private PchInfo pchInfo;
     private String runtime;
     private String mainProjectGUID;
     private String mainProjectRelativePath;
 
-    public ProjectInfo(String projectTemplate, String binding, Set defines, Set includes,
-            Set libraryPaths, Set libraryFiles, Set headerFiles,
-            Set sourceFiles, PchInfo pchInfo, String runtime, String mainProjectGUID, String mainProjectRelativePath)
+    public ProjectInfo( String projectTemplate
+                      , String binding
+                      , Set defines
+                      , Set includes
+                      , Set libraryPaths
+                      , Set libraryFiles
+                      , Set headerFiles
+                      , Set sourceFiles
+                      , String runtime
+                      , String mainProjectGUID
+                      , String mainProjectRelativePath
+                      )
     {
         this.projectTemplate = projectTemplate;
         this.binding = binding;
@@ -34,7 +41,6 @@ public class ProjectInfo
         this.libraryFiles = libraryFiles;
         this.headerFiles = headerFiles;
         this.sourceFiles = sourceFiles;
-        this.pchInfo = pchInfo;
         this.runtime = runtime;
         this.mainProjectGUID = mainProjectGUID;
         this.mainProjectRelativePath = mainProjectRelativePath;
@@ -88,36 +94,6 @@ public class ProjectInfo
     public Set getLibraryFiles() throws MojoExecutionException
     {
         return RelativePathUtils.getRelativePaths(directory, libraryFiles);
-    }
-
-    public String getRelativePchDirectory(boolean debug) throws MojoExecutionException
-    {
-        if(!pchInfo.usePch)
-            return null;
-        String absolutePath = pchInfo.directory + File.separator + (debug ? "debug" : "release");
-        return RelativePathUtils.getRelativePath(directory, absolutePath);
-    }
-
-    public String getPchFileName() throws MojoExecutionException
-    {
-        return pchInfo.pchName;
-    }
-
-    public String getPchBaseDirectory() throws MojoExecutionException
-    {
-        if(!pchInfo.usePch)
-            return null;
-        File baseDir = pchInfo.directory;
-        while(!baseDir.getName().contains(pchInfo.artifactId))
-        {
-            baseDir = baseDir.getParentFile();
-        }
-        return RelativePathUtils.getRelativePath(directory, baseDir.getPath());
-    }
-
-    public boolean usePch()
-    {
-        return pchInfo.usePch;
     }
 
     public String getMainProjectGUID()

--- a/src/main/java/org/apache/maven/plugin/nar/VS2012Project.java
+++ b/src/main/java/org/apache/maven/plugin/nar/VS2012Project.java
@@ -31,18 +31,18 @@ public class VS2012Project
         userFile = new File(directory, name + VCXPROJ_USER_EXTENSION);
     }
 
-    public void createProjectFiles(ProjectInfo info, String narPrecompiledHeaderFilePath) throws MojoExecutionException, MojoFailureException
+    public void createProjectFiles(ProjectInfo info) throws MojoExecutionException, MojoFailureException
     {
         info.setProjectDirectory(directory);
-        createProjectFile(info, narPrecompiledHeaderFilePath);
+        createProjectFile(info);
         createFiltersFile(info);
         createUserFile(info);
     }
 
-    private void createProjectFile(ProjectInfo info ,String narPrecompiledHeaderFilePath) throws MojoExecutionException, MojoFailureException
+    private void createProjectFile(ProjectInfo info) throws MojoExecutionException, MojoFailureException
     {
         VisualStudioTemplateModifier modifier =
-            new VisualStudioProjectTemplateModifier(info, projectFile, GUID, name, narPrecompiledHeaderFilePath);
+            new VisualStudioProjectTemplateModifier(info, projectFile, GUID, name);
         modifier.createPopulatedOutput();
     }
 

--- a/src/main/resources/org/apache/maven/plugin/nar/VS2012ProjectTemplate.txt
+++ b/src/main/resources/org/apache/maven/plugin/nar/VS2012ProjectTemplate.txt
@@ -54,16 +54,12 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>[#usePreCompiledHeader#]</PrecompiledHeader>
       <WarningLevel />
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <TreatWarningAsError>true</TreatWarningAsError>
       <MinimalRebuild />
-      <PrecompiledHeaderFile>[#preCompiledHeader.hDebug#]</PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile />
-      <ProgramDataBaseFileName>[#preCompiledHeader.pdbDebug#]</ProgramDataBaseFileName>
       <CallingConvention />
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <AdditionalOptions>[#defines#] [#forcedIncludesDebug#]%(AdditionalOptions)</AdditionalOptions>
@@ -74,13 +70,9 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>[#librariesDebug#];%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PreBuildEvent>
-      <Command>[#cleanPreCompiledHeaders#][#copyPrecompiledHeaderFile#]</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PrecompiledHeader>[#usePreCompiledHeader#]</PrecompiledHeader>
       <WarningLevel />
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -89,8 +81,6 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <TreatWarningAsError>true</TreatWarningAsError>
       <MinimalRebuild />
-      <PrecompiledHeaderFile>[#preCompiledHeader.h#]</PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile />
       <CallingConvention />
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <AdditionalOptions>[#defines#] [#forcedIncludes#]%(AdditionalOptions)</AdditionalOptions>
@@ -103,9 +93,6 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>[#libraries#];%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PreBuildEvent>
-      <Command>[#cleanPreCompiledHeaders#]</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
 [#headerFileElements#]

--- a/src/main/resources/org/apache/maven/plugin/nar/VS2012TestProjectTemplate.txt
+++ b/src/main/resources/org/apache/maven/plugin/nar/VS2012TestProjectTemplate.txt
@@ -54,16 +54,12 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>[#usePreCompiledHeader#]</PrecompiledHeader>
       <WarningLevel />
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <TreatWarningAsError>true</TreatWarningAsError>
       <MinimalRebuild />
-      <PrecompiledHeaderFile>[#preCompiledHeader.hDebug#]</PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile />
-      <ProgramDataBaseFileName>[#preCompiledHeader.pdbDebug#]</ProgramDataBaseFileName>
       <CallingConvention />
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <AdditionalOptions>[#defines#] [#forcedIncludesDebug#]%(AdditionalOptions)</AdditionalOptions>
@@ -74,16 +70,12 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>[#librariesDebug#];%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PreBuildEvent>
-      <Command>[#cleanPreCompiledHeaders#]</Command>
-    </PreBuildEvent>
     <PostBuildEvent>
       <Command>path=%path%;[#libraryPaths#] &amp;&amp; [#projectName#].exe</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PrecompiledHeader>[#usePreCompiledHeader#]</PrecompiledHeader>
       <WarningLevel />
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -92,8 +84,6 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <TreatWarningAsError>true</TreatWarningAsError>
       <MinimalRebuild />
-      <PrecompiledHeaderFile>[#preCompiledHeader.h#]</PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile />
       <CallingConvention />
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <AdditionalOptions>[#defines#] [#forcedIncludes#]%(AdditionalOptions)</AdditionalOptions>
@@ -106,9 +96,6 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>[#libraries#];%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <PreBuildEvent>
-      <Command>[#cleanPreCompiledHeaders#]</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
 [#headerFileElements#]


### PR DESCRIPTION
Precompiled headers are no longer needed in the client, however compilation flags and other executions are hard-coded into the MNP and forced to be used in the client. Here I remove all references to pch's.